### PR TITLE
fix: resolve ConcurrentModificationException.

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -11,6 +11,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -39,8 +40,9 @@ class LoggerPrinter implements Printer {
    * Provides one-time used tag for the log message
    */
   private final ThreadLocal<String> localTag = new ThreadLocal<>();
+  
+  private final List<LogAdapter> logAdapters = new CopyOnWriteArrayList<>();
 
-  private final List<LogAdapter> logAdapters = new ArrayList<>();
 
   @Override public Printer t(String tag) {
     if (tag != null) {


### PR DESCRIPTION
LoggerPrinter will throw `java.util.ConcurrentModificationException` when `LoggerPrinter.log()` and `LoggerPrinter.addAdapter()/LoggerPrinter.clearLogAdapters()`  invoke in different thread at the same time。